### PR TITLE
Add transparent exclude tab theme

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -16,6 +16,7 @@ const os = require('./platform');
 
 var themeStylePaths = {
 	'Default Dark': '../themes/Default Dark.css',
+	'Dark (Exclude Tab Line)': '../themes/Dark (Exclude Tab Line).css',
 	'Dark (Only Subbar)': '../themes/Dark (Only Subbar).css',
 	'Default Light': '../themes/Default Light.css',
 	'Light (Only Subbar)': '../themes/Light (Only Subbar).css',
@@ -26,6 +27,7 @@ var themeStylePaths = {
 
 const themeConfigPaths = {
 	'Default Dark': '../themes/Default Dark.json',
+	'Dark (Exclude Tab Line)': '../themes/Dark (Exclude Tab Line).json',
 	'Dark (Only Subbar)': '../themes/Dark (Only Subbar).json',
 	'Default Light': '../themes/Default Light.json',
 	'Light (Only Subbar)': '../themes/Light (Only Subbar).json',

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
             "Light (Only Subbar)",
             "Tokyo Night Storm",
             "Tokyo Night Storm (Outer)",
-            "Noir et blanc"
+            "Noir et blanc",
+            "Dark (Exclude Tab Line)"
           ]
         },
         "vscode_vibrancy.imports": {

--- a/themes/Dark (Exclude Tab Line).css
+++ b/themes/Dark (Exclude Tab Line).css
@@ -1,0 +1,75 @@
+.scroll-decoration {
+  box-shadow: none !important;
+}
+
+.minimap, .editor-scrollable>.decorationsOverviewRuler {
+  opacity: 0.6;
+}
+
+.editor-container {
+  background: transparent !important;
+}
+
+.search-view .search-widget .input-box, .search-view .search-widget .input-box .monaco-inputbox,
+.monaco-editor-background,
+.monaco-editor .margin,
+.monaco-workbench .part>.content,
+.monaco-workbench .editor>.content>.one-editor-silo.editor-one,
+.monaco-workbench .part.editor>.content>.one-editor-silo>.container>.title,
+.monaco-workbench .part>.title,
+.monaco-workbench,
+.monaco-workbench .part,
+body {
+  background: transparent !important;
+}
+
+.monaco-list.settings-toc-tree .monaco-list-row.focused {
+  outline-color: rgb(37, 37, 37,0.6) !important;
+}
+
+.monaco-list.settings-toc-tree .monaco-list-row.selected,
+.monaco-list.settings-toc-tree .monaco-list-row.focused,
+.monaco-list .monaco-list-row.selected,
+.monaco-list.settings-toc-tree:not(.drop-target) .monaco-list-row:hover:not(.selected):not(.focused) {
+  background-color: rgb(37, 37, 37,0.6) !important;
+}
+
+.monaco-list.settings-editor-tree .monaco-list-row {
+  background-color: transparent !important;
+  outline-color: transparent !important;
+}
+
+.monaco-inputbox {
+  background-color: rgba(41, 41, 41,0.2) !important;
+}
+
+.monaco-editor .selected-text {
+  background-color: rgba(58, 61, 65,0.6) !important;
+}
+
+.monaco-editor .focused .selected-text {
+  background-color: rgba(38, 79, 120,0.6) !important;
+}
+
+.monaco-editor .view-overlays .current-line {
+  border-color: rgba(41, 41, 41,0.2) !important;
+}
+
+.extension-editor,
+.preferences-editor>.preferences-header,
+.preferences-editor>.preferences-editors-container.side-by-side-preferences-editor .preferences-header-container,
+.monaco-editor, .monaco-editor .inputarea.ime-input,
+.monaco-list .monaco-list-rows {
+  background: transparent !important;
+}
+
+
+.monaco-workbench .part.sidebar {
+  background-color: rgba(37, 37, 38, 0.3) !important;
+}
+
+.terminal-outer-container,
+.xterm-viewport,
+.xterm-rows {
+  background-color: transparent !important;
+}

--- a/themes/Dark (Exclude Tab Line).json
+++ b/themes/Dark (Exclude Tab Line).json
@@ -1,0 +1,12 @@
+{
+  "type": {
+    "win10": "acrylic",
+    "macos": "ultra-dark"
+  },
+  "background": "1e1e1e",
+  "opacity": {
+    "win10": 0.8,
+    "macos": 0.3
+  },
+  "colorTheme": "Default Dark+"
+}


### PR DESCRIPTION
add exclude tab dark theme
To avoid collapse of pinned and unpinned tabs
like this
![image](https://user-images.githubusercontent.com/31244245/189521912-5849f659-ac39-4c25-b6ea-d829f0188f96.png)
