### PR TITLE
Support for .ipynb

### DIFF
--- a/themes/Dark (Exclude Tab Line).css
+++ b/themes/Dark (Exclude Tab Line).css
@@ -73,3 +73,10 @@ body {
 .xterm-rows {
   background-color: transparent !important;
 }
+
+.notebookOverlay.notebook-editor,
+.cell-statusbar-container,
+.margin-view-overlays,
+.monaco-list-row:hover:not(.selected):not(.focused) {
+  background-color: transparent !important;
+}

--- a/themes/Default Dark.css
+++ b/themes/Default Dark.css
@@ -96,3 +96,10 @@ body {
 .monaco-workbench.fullscreen {
 	background-color: #202020 !important;
 }
+
+.notebookOverlay.notebook-editor,
+.cell-statusbar-container,
+.margin-view-overlays,
+.monaco-list-row:hover:not(.selected):not(.focused) {
+  background-color: transparent !important;
+}

--- a/themes/Default Light.css
+++ b/themes/Default Light.css
@@ -122,3 +122,10 @@ body {
 .monaco-workbench.fullscreen {
 	background-color: #ffffff !important;
 }
+
+.notebookOverlay.notebook-editor,
+.cell-statusbar-container,
+.margin-view-overlays,
+.monaco-list-row:hover:not(.selected):not(.focused) {
+  background-color: transparent !important;
+}

--- a/themes/Noir et blanc.css
+++ b/themes/Noir et blanc.css
@@ -207,3 +207,10 @@ body {
 .monaco-workbench.fullscreen {
 	background-color: #ffffff !important;
 }
+
+.notebookOverlay.notebook-editor,
+.cell-statusbar-container,
+.margin-view-overlays,
+.monaco-list-row:hover:not(.selected):not(.focused) {
+  background-color: transparent !important;
+}

--- a/themes/Solarized Dark+.css
+++ b/themes/Solarized Dark+.css
@@ -99,3 +99,10 @@ body {
 .monaco-editor .margin {
   background-color: rgba(0, 53, 69, 0.3) !important;
 }
+
+.notebookOverlay.notebook-editor,
+.cell-statusbar-container,
+.margin-view-overlays,
+.monaco-list-row:hover:not(.selected):not(.focused) {
+  background-color: transparent !important;
+}

--- a/themes/Tokyo Night Storm.css
+++ b/themes/Tokyo Night Storm.css
@@ -124,3 +124,10 @@ body {
 .mtk4,.mtk9.mtk10,.mtk11,.mtk12,.mtk14,.mtk18,.mtk20,.mtk22 {
   text-shadow: 0 0 8px, 0 0 2px #000;
 }
+
+.notebookOverlay.notebook-editor,
+.cell-statusbar-container,
+.margin-view-overlays,
+.monaco-list-row:hover:not(.selected):not(.focused) {
+  background-color: transparent !important;
+}


### PR DESCRIPTION
# Overview

Fixed an issue raised in #62 where the background was not transparent in .ipynb files. (left: original, right: fixed)

<img width="400" alt="image" src="https://github.com/illixion/vscode-vibrancy-continued/assets/93463965/b9742ba1-ee63-40df-b83d-b5a4d21f1f98">
<img width="400" alt="image" src="https://github.com/illixion/vscode-vibrancy-continued/assets/93463965/a790ef20-76e9-48d0-abc2-89db4add8f57">

# Fixes
I directly edited the following css in the [/themes](https://github.com/dike-okayama/vscode-vibrancy-continued/tree/feature/notebook-support/themes) directory.

- Default Dark.css
- Default Light.css
- Noir et blanc.css
- Solarized Dark+.css
- Tokyo Night Storm.css
- Dark (Exclude Tab Line).css

The following css has been added to each file.

```css
.notebookOverlay.notebook-editor,
.cell-statusbar-container,
.margin-view-overlays,
.monaco-list-row:hover:not(.selected):not(.focused) {
  background-color: transparent !important;
}
```

# Detail

The correspondence of the selectors of the changed css is as follows.

- `.notebookOverlay.notebook-editor`
  - Entire display of the .ipynb file
- `.cell-statusbar-container`
  - Status bar in the notebook cell
- `.margin-view-overlays`
  - Left side of the code block in the notebook cell (e.g. where the breakpoint is set)
- `.monaco-list-row:hover:not(.selected):not(.focused)`
  - when hovering over the notebook cell

# Environment

- macOS v13.4.1 (22F82)
- Visual Studio Code v1.79.2