### PR TITLE
Fix tokyo night storm theme

### DIFF
--- a/themes/Tokyo Night Storm.css
+++ b/themes/Tokyo Night Storm.css
@@ -34,6 +34,7 @@
 .monaco-workbench .part > .title,
 .monaco-workbench,
 .monaco-workbench .part,
+.monaco-workbench .pane-header,
 body {
   background: transparent !important;
 }
@@ -82,6 +83,7 @@ body {
 
 .monaco-editor .view-overlays .current-line {
   border-color: rgba(51, 70, 124, 0.2) !important;
+  background-color: rgba(51, 70, 124, 0.2) !important;
 }
 
 .extension-editor,


### PR DESCRIPTION
# Change file
- vscode-vibrancy-continued/themes/Tokyo Night Storm.css

# Fixes 
- panel-header
This area is not emphasized in Tokyo Night Storm and is the same color as the surrounding area. Besides, it was already transparent in the Outer version. Therefore, we modified it from opaque to transparent.
- current-line
In Tokyo Night Storm, this area is slightly emphasized, but only a little bright and did not need to be opaque. Therefore, it was made translucent.

## before
![before image](https://github.com/illixion/vscode-vibrancy-continued/assets/103440382/4d0e3be0-55d4-44a2-8f25-6798a4892787)
## after
![after image](https://github.com/illixion/vscode-vibrancy-continued/assets/103440382/09dae78d-af78-4ef7-94b7-5fdb323ee67a)
