### PR TITLE
Fixed bug where minimap was not visible in the catppuccin mocha theme

### DIFF
--- a/themes/Catppuccin Mocha.css
+++ b/themes/Catppuccin Mocha.css
@@ -142,11 +142,6 @@ body {
   background-color: var(--base-background) !important;
 }
 
-.minimap,
-.editor-scrollable > .decorationsOverviewRuler {
-  opacity: 0 !important;
-}
-
 #workbench\.parts\.editor
   > div.content.empty
   > div


### PR DESCRIPTION
Minimap was invisible (0 opacity) only for the catppuccin mocha theme. In other themes the minimap was visible. Removed the override that set it's opacity to 0. If people wish to hide the minimap, they can do so in standard vscode settings with `>Toggle Minimap`