### PR TITLE
fix: Correct spelling of "preferred" in configuration keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Refresh interval (in milliseconds) for making the background transparent after w
 Enable automatic dark/light mode switching based on OS mode. Requires `window.autoDetectColorScheme` VSCode setting to also be enabled.
 *boolean, default is false*
 
-#### vscode_vibrancy.preferedDarkTheme / vscode_vibrancy.preferedLightTheme
+#### vscode_vibrancy.preferredDarkTheme / vscode_vibrancy.preferredLightTheme
 
 Select which themes to use for light and dark modes, they will be used instead of the main Vibrancy theme selected.
 
@@ -115,9 +115,9 @@ Select which themes to use for light and dark modes, they will be used instead o
 Select Vibrancy theme:
 
 * Default Dark
-* Dark (Only Subbar)
+* Dark (Only Sub-bar)
 * Default Light
-* Light (Only Subbar)
+* Light (Only Sub-bar)
 * Noir et blanc
 * Tokyo Night Storm
 * Tokyo Night Storm (Outer)

--- a/extension/index.js
+++ b/extension/index.js
@@ -56,8 +56,8 @@ function checkDarkLightMode(theme) {
   const currentTheme = theme.kind;
 
   const currentColorTheme = vscode.workspace.getConfiguration().get("vscode_vibrancy.theme");
-  const preferredDarkColorTheme = vscode.workspace.getConfiguration().get("vscode_vibrancy.preferedDarkTheme");
-  const preferredLightColorTheme = vscode.workspace.getConfiguration().get("vscode_vibrancy.preferedLightTheme");
+  const preferredDarkColorTheme = vscode.workspace.getConfiguration().get("vscode_vibrancy.preferredDarkTheme");
+  const preferredLightColorTheme = vscode.workspace.getConfiguration().get("vscode_vibrancy.preferredLightTheme");
 
   let targetVibrancyTheme;
   if (currentTheme === vscode.ColorThemeKind.Dark) {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
           "type": "boolean",
           "default": false
         },
-        "vscode_vibrancy.preferedDarkTheme": {
+        "vscode_vibrancy.preferredDarkTheme": {
           "type": "string",
           "default": "Default Dark",
           "enum": [
@@ -153,7 +153,7 @@
             "Custom theme (use imports)"
           ]
         },
-        "vscode_vibrancy.preferedLightTheme": {
+        "vscode_vibrancy.preferredLightTheme": {
           "type": "string",
           "default": "Default Light",
           "enum": [


### PR DESCRIPTION
# Fix spelling errors in configuration keys for preferred dark and light themes.

Correct the spelling from `prefered` to `preferred`