### PR TITLE
fix Paradise Smoked Glass aux-bar tabs and status-bar color

### DIFF
--- a/themes/Paradise Smoked Glass.css
+++ b/themes/Paradise Smoked Glass.css
@@ -60,7 +60,8 @@ body {
 
 
 .monaco-workbench .activitybar>.content :not(.monaco-menu)>.monaco-action-bar li:not(.checked)>.action-label.codicon,
-.monaco-workbench .part.panel.bottom .composite.title .composite-bar .actions-container > .action-item:not(.checked) > .action-label {
+.monaco-workbench .part.panel.bottom .composite.title .composite-bar .actions-container > .action-item:not(.checked) > .action-label,
+.monaco-workbench .part.auxiliarybar>.title .monaco-action-bar li.action-item:not(.checked) > .action-label {
     color: rgba(255, 255, 255, 0.5) !important;
 }
 

--- a/themes/Paradise Smoked Glass.css
+++ b/themes/Paradise Smoked Glass.css
@@ -83,16 +83,16 @@ body:has(.monaco-workbench.fullscreen) {
 }
 
 #status\.host {
-    background-color: rgb(140, 151, 125, .75) !important;
+    background-color: rgba(178, 197, 152, 0.65) !important;
 }
 
 .monaco-workbench .part.statusbar {
-    background-color: rgb(100, 131, 163, .6) !important;
+    background-color: rgba(155, 205, 255, 0.5) !important;
 }
 
 body:has(.codicon-debug-stop){
     .monaco-workbench .part.statusbar {
-        background-color: rgb(182, 100, 103, .6) !important;
+        background-color: rgba(255, 136, 140, 0.5) !important;
     }
 }
 


### PR DESCRIPTION
Brightened the colors in the status-bar while keeping transparency.

> ### Before
> <img width="698" height="191" alt="status-color-old" src="https://github.com/user-attachments/assets/81f1ebd2-853d-4c1c-a9b5-8cc42cd20ca0" />

> ### After
> <img width="698" height="191" alt="status-color-new" src="https://github.com/user-attachments/assets/4a6db9cc-d922-43e6-8fd6-5ccd12ae849c" />

Corrected issue where unchecked aux-bar tab names would wash into the background when there were multiple tabs.

> ### Before
> <img width="406" height="171" alt="aux-bar-issue" src="https://github.com/user-attachments/assets/24e0be34-2239-47f8-83b4-761281b5f519" />


> ### After
> <img width="406" height="171" alt="aux-bar-fixed" src="https://github.com/user-attachments/assets/f947ff32-ec2e-4a3e-9128-ad926c4f4303" />
