### PR TITLE
Fixed opaque terminal background

### DIFF
--- a/themes/fixes/Paradise Cursor.css
+++ b/themes/fixes/Paradise Cursor.css
@@ -4,7 +4,8 @@
 .composer-sticky-human-message::before,
 .monaco-workbench .part.panel .pane-body.integrated-terminal .terminal-outer-container
 .terminal.xterm .xterm-scrollable-element,
-.composer-bar .conversations > div > div > .scrollable-div-container > .monaco-scrollable-element > div:not(.scrollbar) > div > div > div > div {
+.composer-bar .conversations > div > div > .scrollable-div-container > .monaco-scrollable-element > div:not(.scrollbar) > div > div > div > div,
+.terminal-outer-container {
     background-color: transparent !important;
 }
 


### PR DESCRIPTION
Recent Cursor update changed the `background-color` of one of the elements behind the terminal, this PR makes that element transparent again.