### PR TITLE
Makes floating menus and tooltips semi-opaque in Paradise Cursor fix

### DIFF
--- a/themes/fixes/Paradise Cursor.css
+++ b/themes/fixes/Paradise Cursor.css
@@ -1,3 +1,12 @@
+.monaco-workbench {
+    --cursor-bg-elevated: var(--semi-opaque) !important;
+}
+
+.ui-menu,
+.ui-tooltip {
+    backdrop-filter: blur(10px) !important;
+}
+
 .monaco-workbench .part.auxiliarybar .composer-bar.editor,
 .monaco-workbench .part.auxiliarybar .composer-bar .conversations,
 .monaco-workbench .part.auxiliarybar .composer-bar .composer-rendered-message,


### PR DESCRIPTION
Updates styles for floating UI elements (like the model selector and model tooltips) in the Paradise Cursor fix to improve readability and match the rest of the theme.