### PR TITLE
Feature/fix cursor unfocused display vibrancy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         #   os: [self-hosted-linux, self-hosted-macos, self-hosted-windows]
         # Self-hosted runners need: Node.js 20+, git, and a desktop session.
         # On Linux self-hosted: also install imagemagick.
-        os: [ubuntu-latest, macos-latest, windows-11-arm]
+        os: [ubuntu-latest, macos-26, windows-11-arm]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/extension/file-transforms.js
+++ b/extension/file-transforms.js
@@ -79,6 +79,100 @@ function removeJSMarkers(js) {
 // --- Electron BrowserWindow Options ---
 
 /**
+ * Inject options before the `experimentalDarkMode` anchor used by bundled
+ * VSCode BrowserWindow object literals.
+ * @param {string} electronJS - Electron main.js content
+ * @param {string} injectedOptions - Comma-delimited options to prepend
+ * @returns {string} Patched content, or the original string if no anchor exists
+ */
+function injectObjectLiteralWindowOptions(electronJS, injectedOptions) {
+  return electronJS.replace(
+    /experimentalDarkMode/g,
+    `${injectedOptions},experimentalDarkMode`
+  );
+}
+
+/**
+ * Inject options before the `titleBarStyle="hidden"` assignment used by newer
+ * Cursor window builders.
+ * @param {string} electronJS - Electron main.js content
+ * @param {(target: string, quote: string) => string} createInjectedOptions
+ * @returns {string} Patched content, or the original string if no anchor exists
+ */
+function injectCursorWindowOptions(electronJS, createInjectedOptions) {
+  return electronJS.replace(
+    /([A-Za-z_$][\w$]*)\.titleBarStyle=(["'])hidden\2,/g,
+    (_, target, quote) =>
+      `${createInjectedOptions(target, quote)}${target}.titleBarStyle=${quote}hidden${quote},`
+  );
+}
+
+/**
+ * Remove assignment-style window options injected into newer Cursor bundles.
+ * @param {string} electronJS - Electron main.js content
+ * @returns {string} Cleaned content
+ */
+function removeCursorWindowOptions(electronJS) {
+  return electronJS
+    .replace(/([A-Za-z_$][\w$]*)\.frame=false,\1\.transparent=true,/g, '')
+    .replace(/[A-Za-z_$][\w$]*\.visualEffectState=(["'])active\1,/g, '');
+}
+
+/**
+ * Inject macOS-only visual effect state into Electron window builders.
+ * @param {string} electronJS - Electron main.js content
+ * @returns {string} Patched content
+ */
+function injectVisualEffectState(electronJS) {
+  if (
+    electronJS.includes('visualEffectState:"active"') ||
+    /[A-Za-z_$][\w$]*\.visualEffectState=(["'])active\1,/.test(electronJS)
+  ) {
+    return electronJS;
+  }
+
+  const objectLiteralPatched = injectObjectLiteralWindowOptions(
+    electronJS,
+    'visualEffectState:"active"'
+  );
+  if (objectLiteralPatched !== electronJS) {
+    return objectLiteralPatched;
+  }
+
+  return injectCursorWindowOptions(
+    electronJS,
+    (target, quote) => `${target}.visualEffectState=${quote}active${quote},`
+  );
+}
+
+/**
+ * Inject frameless-window options into Electron window builders.
+ * @param {string} electronJS - Electron main.js content
+ * @returns {string} Patched content
+ */
+function injectFramelessWindow(electronJS) {
+  if (
+    electronJS.includes('frame:false,transparent:true') ||
+    /([A-Za-z_$][\w$]*)\.frame=false,\1\.transparent=true,/.test(electronJS)
+  ) {
+    return electronJS;
+  }
+
+  const objectLiteralPatched = injectObjectLiteralWindowOptions(
+    electronJS,
+    'frame:false,transparent:true'
+  );
+  if (objectLiteralPatched !== electronJS) {
+    return objectLiteralPatched;
+  }
+
+  return injectCursorWindowOptions(
+    electronJS,
+    (target) => `${target}.frame=false,${target}.transparent=true,`
+  );
+}
+
+/**
  * Inject Electron BrowserWindow options (frame, transparent, visualEffectState).
  * @param {string} electronJS - Electron main.js content
  * @param {{ useFrame: boolean, isMacos: boolean }} opts
@@ -87,14 +181,14 @@ function removeJSMarkers(js) {
 function injectElectronOptions(electronJS, { useFrame, isMacos }) {
   let result = electronJS;
 
-  // Add visualEffectState to keep vibrancy active when unfocused (macOS only)
-  if (!result.includes('visualEffectState') && isMacos) {
-    result = result.replace(/experimentalDarkMode/g, 'visualEffectState:"active",experimentalDarkMode');
+  // visualEffectState is a macOS-only Electron option.
+  if (isMacos) {
+    result = injectVisualEffectState(result);
   }
 
   // Add frameless + transparent window options
-  if (useFrame && !result.includes('frame:false,')) {
-    result = result.replace(/experimentalDarkMode/g, 'frame:false,transparent:true,experimentalDarkMode');
+  if (useFrame) {
+    result = injectFramelessWindow(result);
   }
 
   return result;
@@ -106,9 +200,13 @@ function injectElectronOptions(electronJS, { useFrame, isMacos }) {
  * @returns {string} Cleaned content
  */
 function removeElectronOptions(electronJS) {
-  return electronJS
+  const withoutObjectLiteralOptions = electronJS
+    .replace(/visualEffectState:"active",frame:false,transparent:true,experimentalDarkMode/g, 'experimentalDarkMode')
+    .replace(/frame:false,transparent:true,visualEffectState:"active",experimentalDarkMode/g, 'experimentalDarkMode')
     .replace(/frame:false,transparent:true,experimentalDarkMode/g, 'experimentalDarkMode')
     .replace(/visualEffectState:"active",experimentalDarkMode/g, 'experimentalDarkMode');
+
+  return removeCursorWindowOptions(withoutObjectLiteralOptions);
 }
 
 // --- CSP / HTML ---

--- a/test/fixtures/cursor-window-builder.js
+++ b/test/fixtures/cursor-window-builder.js
@@ -1,0 +1,5 @@
+function buildWindowOptions(o, i, B, F5) {
+  const u = {};
+  !Bo(o, i?.forceNativeTitlebar ? "native" : $0(o, i)) && (u.titleBarStyle="hidden",B||(u.frame=!1),F5(o, i));
+  return u;
+}

--- a/test/integration/install-uninstall.test.js
+++ b/test/integration/install-uninstall.test.js
@@ -11,9 +11,11 @@ const {
 } = require('../../extension/file-transforms');
 
 const FIXTURES = path.join(__dirname, '..', 'fixtures');
+const loadFixture = (name) => fs.readFileSync(path.join(FIXTURES, name), 'utf-8');
 
 describe('install/uninstall round-trip', () => {
   let tmpDir;
+  const cursorWindowBuilder = loadFixture('cursor-window-builder.js');
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vibrancy-integration-'));
@@ -156,6 +158,12 @@ describe('install/uninstall round-trip', () => {
       const { result, noMetaTag } = patchCSP(original);
       expect(noMetaTag).toBe(true);
       expect(result).toBe(original);
+    });
+
+    it('round-trips assignment-based Cursor window builders', () => {
+      const injected = injectElectronOptions(cursorWindowBuilder, { useFrame: true, isMacos: true });
+      const cleaned = removeElectronOptions(injected);
+      expect(cleaned).toBe(cursorWindowBuilder);
     });
   });
 });

--- a/test/unit/file-transforms.test.js
+++ b/test/unit/file-transforms.test.js
@@ -20,6 +20,7 @@ const {
 
 const FIXTURES = path.join(__dirname, '..', 'fixtures');
 const loadFixture = (name) => fs.readFileSync(path.join(FIXTURES, name), 'utf-8');
+const cursorWindowBuilder = loadFixture('cursor-window-builder.js');
 
 // --- generateNewJS ---
 
@@ -111,9 +112,25 @@ describe('injectElectronOptions', () => {
     expect(result).toContain('frame:false,transparent:true');
   });
 
+  it('injects visualEffectState into assignment-based Cursor window builders', () => {
+    const result = injectElectronOptions(cursorWindowBuilder, { useFrame: false, isMacos: true });
+    expect(result).toContain('u.visualEffectState="active",u.titleBarStyle="hidden"');
+  });
+
+  it('injects frameless options into assignment-based Cursor window builders', () => {
+    const result = injectElectronOptions(cursorWindowBuilder, { useFrame: true, isMacos: false });
+    expect(result).toContain('u.frame=false,u.transparent=true,u.titleBarStyle="hidden"');
+  });
+
   it('does not double-inject if already present', () => {
     const original = loadFixture('main-merged.js');
     const first = injectElectronOptions(original, { useFrame: true, isMacos: true });
+    const second = injectElectronOptions(first, { useFrame: true, isMacos: true });
+    expect(second).toBe(first);
+  });
+
+  it('does not double-inject assignment-based window builders', () => {
+    const first = injectElectronOptions(cursorWindowBuilder, { useFrame: true, isMacos: true });
     const second = injectElectronOptions(first, { useFrame: true, isMacos: true });
     expect(second).toBe(first);
   });
@@ -130,6 +147,11 @@ describe('removeElectronOptions', () => {
   it('removes visualEffectState', () => {
     const injected = 'visualEffectState:"active",experimentalDarkMode';
     expect(removeElectronOptions(injected)).toBe('experimentalDarkMode');
+  });
+
+  it('removes assignment-based Cursor injections', () => {
+    const injected = injectElectronOptions(cursorWindowBuilder, { useFrame: true, isMacos: true });
+    expect(removeElectronOptions(injected)).toBe(cursorWindowBuilder);
   });
 
   it('round-trips: inject then remove produces original', () => {


### PR DESCRIPTION
Please, refer to the issue of this PR for more information

## Summary
- fix macOS inactive-window vibrancy for newer Cursor bundles
- add regression coverage for Cursor-style window builders
- clean up helper docs and test fixture structure

## Test plan
- [x] npm test
- [x] verified locally in Cursor on macOS with two displays
- [x] confirmed vibrancy stays visible when focus moves to another display

Closes https://github.com/illixion/vscode-vibrancy-continued/issues/253

## PS
This fix resolves the issue for me, particularly. I tried to comply with the best practices that I noticed in the repo. However, if something is wrong or can be improved, please tell me, and I will be glad to develop a better commit according to your expectations