### PR TITLE
Feature/fix cursor chat popover opacity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         #   os: [self-hosted-linux, self-hosted-macos, self-hosted-windows]
         # Self-hosted runners need: Node.js 20+, git, and a desktop session.
         # On Linux self-hosted: also install imagemagick.
-        os: [ubuntu-latest, macos-latest, windows-11-arm]
+        os: [ubuntu-latest, macos-26, windows-11-arm]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/themes/fixes/Cursor Dark.css
+++ b/themes/fixes/Cursor Dark.css
@@ -107,6 +107,23 @@
     background-color: var(--vibrancy-soft-background) !important;
 }
 
+/* Edit-previous-message overlay: the inline editor is rendered inside the
+   bubble being edited, with the rest of the chat scrolling behind it.
+   Force it opaque so message text doesn't bleed through. Scoped to bubbles
+   only, so the main composer at the bottom keeps its translucent look. */
+.monaco-workbench .part.auxiliarybar [id^='bubble-'] .full-input-box {
+    background-color: var(--vibrancy-opaque-background) !important;
+}
+
+/* Cursor floating popovers (slash-command menu, agent-history menu, etc.)
+   are rendered via a floating-ui portal outside .part.auxiliarybar, so the
+   sidebar-scoped rules above don't reach them. They inherit the workbench
+   transparency and become unreadable over the editor/chat. Make them opaque. */
+.ui-slash-menu__content,
+.composer-history-hover-menu {
+    background-color: var(--vibrancy-opaque-background) !important;
+}
+
 .monaco-workbench .part.auxiliarybar .empty-pane-message-area {
     background-color: transparent !important;
 }

--- a/themes/fixes/Cursor Light.css
+++ b/themes/fixes/Cursor Light.css
@@ -106,6 +106,23 @@
     background-color: var(--vibrancy-soft-background) !important;
 }
 
+/* Edit-previous-message overlay: the inline editor is rendered inside the
+   bubble being edited, with the rest of the chat scrolling behind it.
+   Force it opaque so message text doesn't bleed through. Scoped to bubbles
+   only, so the main composer at the bottom keeps its translucent look. */
+.monaco-workbench .part.auxiliarybar [id^="bubble-"] .full-input-box {
+    background-color: var(--vibrancy-opaque-background) !important;
+}
+
+/* Cursor floating popovers (slash-command menu, agent-history menu, etc.)
+   are rendered via a floating-ui portal outside .part.auxiliarybar, so the
+   sidebar-scoped rules above don't reach them. They inherit the workbench
+   transparency and become unreadable over the editor/chat. Make them opaque. */
+.ui-slash-menu__content,
+.composer-history-hover-menu {
+    background-color: var(--vibrancy-opaque-background) !important;
+}
+
 .monaco-workbench .part.auxiliarybar .empty-pane-message-area {
     background-color: transparent !important;
 }


### PR DESCRIPTION
## Before

1. Chat history

<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/238586cf-ae94-46f2-a804-4ee18a4c5e0a" />

2. Edit previous message

<img width="1919" height="1080" alt="Image" src="https://github.com/user-attachments/assets/1c84f253-e970-4d8b-b68f-c6ce5a607a92" />

3. Slash command

<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/de176b06-b5eb-4a04-81a7-cc6e2ebf866b" />

## After

1. Chat history

<img width="1920" height="1078" alt="Screenshot 2026-05-25 at 10 50 47 PM" src="https://github.com/user-attachments/assets/b3091fc2-508f-46a7-806a-c5aa4ba3da85" />

2. Edit previous message

<img width="1920" height="1080" alt="Screenshot 2026-05-25 at 10 51 23 PM" src="https://github.com/user-attachments/assets/092788eb-4acc-4229-9581-b5a674d14e40" />

3. Slash command

<img width="1920" height="1080" alt="Screenshot 2026-05-25 at 10 51 36 PM" src="https://github.com/user-attachments/assets/ae940f64-5d98-44d5-8404-66c553d28658" />

Partially closes https://github.com/illixion/vscode-vibrancy-continued/issues/252

