### PR TITLE
add Devin IDE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ If you don't have the option to hide the alert, or to fix an `[Unsupported]` war
 
 ✔ Antigravity
 
+✔ Devin
+
 Some editors may present a [persistent warning](#️-your-vscode-installation-appears-to-be-corrupt) warning about the installation being corrupted, use this extension to fix it: [Fix VSCode Checksums Next](https://marketplace.visualstudio.com/items?itemName=RimuruChan.vscode-fix-checksums-next).
 
 # Getting Started

--- a/extension/index.js
+++ b/extension/index.js
@@ -91,7 +91,8 @@ const knownEditors = [
   'VSCodium',
   'Cursor',
   'Code - OSS',
-  'Antigravity'
+  'Antigravity',
+  'Devin',
 ];
 
 // Map editor app names to their CLI commands for relaunch
@@ -102,6 +103,7 @@ const editorCliCommands = {
   'Cursor': 'cursor',
   'Code - OSS': 'code-oss',
   'Antigravity': 'antigravity',
+  'Devin': 'devin-desktop',
 };
 
 // Map editor app names to their config directory names (for settings.json path)
@@ -112,6 +114,7 @@ const editorConfigDirNames = {
   'Cursor': 'Cursor',
   'Code - OSS': 'Code - OSS',
   'Antigravity': 'Antigravity',
+  'Devin': 'Devin',
 };
 
 var defaultTheme = 'Default Dark';


### PR DESCRIPTION
## Problem

Devin is a VS Code-based editor (formerly known as Windsurf, rebranded by Exafunction), but it is not recognized as a supported editor in recent versions of Vibrancy Continued, resulting in:

Your code editor is not supported, see extension description for the list of supported editors.

Devin worked with v1.1.79, but broke after the v1.1.80 patch that tightened supported-editor checks. Users have been forced to stay on v1.1.79 as a workaround, with `disableFramelessWindow: true` to avoid frameless window issues.

## Devin identification

Confirmed from `/Applications/Devin.app/Contents/Resources/app/product.json`:

| Field | Value |
|---|---|
| `nameShort` | `Devin` |
| `applicationName` | `devin-desktop` |
| `dataFolderName` | `.devin` |
| `win32AppUserModelId` | `Exafunction.Windsurf` |

`vscode.env.appName` → `"Devin"`

## Changes

- Add `'Devin'` to `knownEditors`
- Add `'Devin': 'devin-desktop'` to `editorCliCommands` (confirmed in app bundle `bin/`)
- Add `'Devin': 'Devin'` to `editorConfigDirNames` (confirmed: `~/Library/Application Support/Devin/User/settings.json`)
- Add Devin to supported editors list in README

## Testing

Tested on macOS by installing the patched VSIX directly into Devin. All scenarios passed:

- ✅ `Reload Vibrancy` succeeds — no "unsupported editor" error
- ✅ Vibrancy effect applies correctly after restart
- ✅ `disableFramelessWindow: true` — window behavior normal, vibrancy active
- ✅ `disableFramelessWindow: false` — frameless mode works, no black screen or rendering issues
- ✅ `Disable Vibrancy` restores cleanly, editor reopens without errors
- ✅ User settings not corrupted across multiple restart cycles

**Environment:**
- OS: macOS
- Editor: Devin
- Vibrancy Continued: local development build (based on current `development` branch)